### PR TITLE
Perf: Benchmark Xdebug performance

### DIFF
--- a/.github/benchmark-files/bench.php
+++ b/.github/benchmark-files/bench.php
@@ -1,0 +1,353 @@
+<?php
+if (function_exists("date_default_timezone_set")) {
+    date_default_timezone_set("UTC");
+}
+
+function simple() {
+  $a = 0;
+  for ($i = 0; $i < 1000000; $i++)
+    $a++;
+
+  $thisisanotherlongname = 0;
+  for ($thisisalongname = 0; $thisisalongname < 1000000; $thisisalongname++)
+    $thisisanotherlongname++;
+}
+
+/****/
+
+function simplecall() {
+  for ($i = 0; $i < 1000000; $i++)
+    strlen("hallo");
+}
+
+/****/
+
+function hallo($a) {
+}
+
+function simpleucall() {
+  for ($i = 0; $i < 1000000; $i++)
+    hallo("hallo");
+}
+
+/****/
+
+function simpleudcall() {
+  for ($i = 0; $i < 1000000; $i++)
+    hallo2("hallo");
+}
+
+function hallo2($a) {
+}
+
+/****/
+
+function Ack($m, $n){
+  if($m == 0) return $n+1;
+  if($n == 0) return Ack($m-1, 1);
+  return Ack($m - 1, Ack($m, ($n - 1)));
+}
+
+function ackermann($n) {
+  $r = Ack(3,$n);
+  print "Ack(3,$n): $r\n";
+}
+
+/****/
+
+function ary($n) {
+  for ($i=0; $i<$n; $i++) {
+    $X[$i] = $i;
+  }
+  for ($i=$n-1; $i>=0; $i--) {
+    $Y[$i] = $X[$i];
+  }
+  $last = $n-1;
+  print "$Y[$last]\n";
+}
+
+/****/
+
+function ary2($n) {
+  for ($i=0; $i<$n;) {
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+    $X[$i] = $i; ++$i;
+  }
+  for ($i=$n-1; $i>=0;) {
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+    $Y[$i] = $X[$i]; --$i;
+  }
+  $last = $n-1;
+  print "$Y[$last]\n";
+}
+
+/****/
+
+function ary3($n) {
+  for ($i=0; $i<$n; $i++) {
+    $X[$i] = $i + 1;
+    $Y[$i] = 0;
+  }
+  for ($k=0; $k<1000; $k++) {
+    for ($i=$n-1; $i>=0; $i--) {
+      $Y[$i] += $X[$i];
+    }
+  }
+  $last = $n-1;
+  print "$Y[0] $Y[$last]\n";
+}
+
+/****/
+
+/****/
+
+function hash1($n) {
+  for ($i = 1; $i <= $n; $i++) {
+    $X[dechex($i)] = $i;
+  }
+  $c = 0;
+  for ($i = $n; $i > 0; $i--) {
+    if ($X[dechex($i)]) { $c++; }
+  }
+  print "$c\n";
+}
+
+/****/
+
+function hash2($n) {
+  for ($i = 0; $i < $n; $i++) {
+    $hash1["foo_$i"] = $i;
+    $hash2["foo_$i"] = 0;
+  }
+  for ($i = $n; $i > 0; $i--) {
+    foreach($hash1 as $key => $value) $hash2[$key] += $value;
+  }
+  $first = "foo_0";
+  $last  = "foo_".($n-1);
+  print "$hash1[$first] $hash1[$last] $hash2[$first] $hash2[$last]\n";
+}
+
+/****/
+
+function gen_random ($n) {
+    global $LAST;
+    return( ($n * ($LAST = ($LAST * IA + IC) % IM)) / IM );
+}
+
+function heapsort_r($n, &$ra) {
+    $l = ($n >> 1) + 1;
+    $ir = $n;
+
+    while (1) {
+    if ($l > 1) {
+        $rra = $ra[--$l];
+    } else {
+        $rra = $ra[$ir];
+        $ra[$ir] = $ra[1];
+        if (--$ir == 1) {
+        $ra[1] = $rra;
+        return;
+        }
+    }
+    $i = $l;
+    $j = $l << 1;
+    while ($j <= $ir) {
+        if (($j < $ir) && ($ra[$j] < $ra[$j+1])) {
+        $j++;
+        }
+        if ($rra < $ra[$j]) {
+        $ra[$i] = $ra[$j];
+        $j += ($i = $j);
+        } else {
+        $j = $ir + 1;
+        }
+    }
+    $ra[$i] = $rra;
+    }
+}
+
+function heapsort($N) {
+  global $LAST;
+
+  define("IM", 139968);
+  define("IA", 3877);
+  define("IC", 29573);
+
+  $LAST = 42;
+  for ($i=1; $i<=$N; $i++) {
+    $ary[$i] = gen_random(1);
+  }
+  heapsort_r($N, $ary);
+  printf("%.10f\n", $ary[$N]);
+}
+
+/****/
+
+function mkmatrix ($rows, $cols) {
+    $count = 1;
+    $mx = array();
+    for ($i=0; $i<$rows; $i++) {
+    for ($j=0; $j<$cols; $j++) {
+        $mx[$i][$j] = $count++;
+    }
+    }
+    return($mx);
+}
+
+function mmult ($rows, $cols, $m1, $m2) {
+    $m3 = array();
+    for ($i=0; $i<$rows; $i++) {
+    for ($j=0; $j<$cols; $j++) {
+        $x = 0;
+        for ($k=0; $k<$cols; $k++) {
+        $x += $m1[$i][$k] * $m2[$k][$j];
+        }
+        $m3[$i][$j] = $x;
+    }
+    }
+    return($m3);
+}
+
+function matrix($n) {
+  $SIZE = 30;
+  $m1 = mkmatrix($SIZE, $SIZE);
+  $m2 = mkmatrix($SIZE, $SIZE);
+  while ($n--) {
+    $mm = mmult($SIZE, $SIZE, $m1, $m2);
+  }
+  print "{$mm[0][0]} {$mm[2][3]} {$mm[3][2]} {$mm[4][4]}\n";
+}
+
+/****/
+
+function nestedloop($n) {
+  $x = 0;
+  for ($a=0; $a<$n; $a++)
+    for ($b=0; $b<$n; $b++)
+      for ($c=0; $c<$n; $c++)
+        for ($d=0; $d<$n; $d++)
+          for ($e=0; $e<$n; $e++)
+            for ($f=0; $f<$n; $f++)
+             $x++;
+  print "$x\n";
+}
+
+/****/
+
+function sieve($n) {
+  $count = 0;
+  while ($n-- > 0) {
+    $count = 0;
+    $flags = range (0,8192);
+    for ($i=2; $i<8193; $i++) {
+      if ($flags[$i] > 0) {
+        for ($k=$i+$i; $k <= 8192; $k+=$i) {
+          $flags[$k] = 0;
+        }
+        $count++;
+      }
+    }
+  }
+  print "Count: $count\n";
+}
+
+/****/
+
+function strcat($n) {
+  $str = "";
+  while ($n-- > 0) {
+    $str .= "hello\n";
+  }
+  $len = strlen($str);
+  print "$len\n";
+}
+
+/*****/
+
+function gethrtime()
+{
+  $hrtime = hrtime();
+  return (($hrtime[0]*1000000000 + $hrtime[1]) / 1000000000);
+}
+
+function start_test()
+{
+    ob_start();
+  return gethrtime();
+}
+
+function end_test($start, $name)
+{
+  global $total;
+  $end = gethrtime();
+  ob_end_clean();
+  $total += $end-$start;
+  $num = number_format($end-$start,3);
+  $pad = str_repeat(" ", 24-strlen($name)-strlen($num));
+
+  echo $name.$pad.$num."\n";
+    ob_start();
+  return gethrtime();
+}
+
+function total()
+{
+  global $total;
+  $pad = str_repeat("-", 24);
+  echo $pad."\n";
+  $num = number_format($total,3);
+  $pad = str_repeat(" ", 24-strlen("Total")-strlen($num));
+  echo "Total".$pad.$num."\n";
+}
+
+$t0 = $t = start_test();
+simple();
+$t = end_test($t, "simple");
+simplecall();
+$t = end_test($t, "simplecall");
+simpleucall();
+$t = end_test($t, "simpleucall");
+simpleudcall();
+$t = end_test($t, "simpleudcall");
+ackermann(7);
+$t = end_test($t, "ackermann(7)");
+ary(50000);
+$t = end_test($t, "ary(50000)");
+ary2(50000);
+$t = end_test($t, "ary2(50000)");
+ary3(2000);
+$t = end_test($t, "ary3(2000)");
+hash1(50000);
+$t = end_test($t, "hash1(50000)");
+hash2(500);
+$t = end_test($t, "hash2(500)");
+heapsort(20000);
+$t = end_test($t, "heapsort(20000)");
+matrix(20);
+$t = end_test($t, "matrix(20)");
+nestedloop(12);
+$t = end_test($t, "nestedloop(12)");
+sieve(30);
+$t = end_test($t, "sieve(30)");
+strcat(200000);
+$t = end_test($t, "strcat(200000)");
+total();
+?>

--- a/.github/benchmark-files/benchmark.ini
+++ b/.github/benchmark-files/benchmark.ini
@@ -1,0 +1,11 @@
+max_execution_time=0
+error_reporting=0
+display_errors=off
+log_errors=off
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit=disable
+opcache.validate_timestamps=0
+opcache.optimization_level=0
+opcache.file_cache=/tmp/opcache/
+opcache.file_cache_only=1

--- a/.github/benchmark-files/rector.php
+++ b/.github/benchmark-files/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+
+return RectorConfig::configure()
+    ->withPreparedSets(
+        rectorPreset: true,
+    )
+    ->withPaths([
+        __DIR__ . '/.github/benchmark-files/rector.php',
+    ])
+;

--- a/.github/benchmark-files/xdebug-benchmark.ini
+++ b/.github/benchmark-files/xdebug-benchmark.ini
@@ -1,0 +1,3 @@
+zend_extension=xdebug.so
+xdebug.start_with_request=no
+xdebug.max_nesting_level=2048

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,181 @@
+name: Benchmark Xdebug performance
+
+on:
+    schedule:
+        # Every Sunday at 03:00 UTC
+        - cron: '0 3 * * 0'
+    workflow_dispatch: 
+    pull_request:
+        types: [opened, edited, reopened, synchronize]
+
+jobs:
+    run-benchmark:
+        if: |
+            github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+            (
+                github.event_name == 'pull_request' &&
+                (
+                    startsWith(github.event.pull_request.title, 'perf:') ||
+                    startsWith(github.event.pull_request.title, 'Perf:') ||
+                    startsWith(github.event.pull_request.title, 'Performance:') ||
+                    startsWith(github.event.pull_request.title, 'performance:')
+                )
+            )
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                command: ["bench", "symfony", "rector"]
+                php: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+                xdebug_mode: ["no", "off", "develop", "coverage", "debug", "gcstats", "profile", "trace"]
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    coverage: none
+                    tools: composer:v2.2.21
+
+            # ASLR can cause a lot of noise due to missed sse opportunities for memcpy
+            # and other operations, so we disable it during benchmarking.
+            -   name: Disable ASLR
+                run: echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+
+            -   name: Install valgrind
+                run: sudo apt-get update && sudo apt-get install -y valgrind
+                    
+            -   name: Compile
+                run: |
+                    ./.build.scripts/compile.sh
+                    sudo make install
+
+            -   name: create results and opcache folder
+                run: |
+                    mkdir -p results
+                    mkdir -p /tmp/opcache
+
+            -   name: install Symfony demo
+                if: matrix.command == 'symfony'   
+                run: |
+                    if [ "${{ matrix.php }}" \< "8.4" ]; then
+                        version="v2.0.2"
+                    else
+                        version="v2.7.0"
+                    fi
+                    git clone -q --branch "$version" --depth 1 https://github.com/symfony/demo.git ./symfony-demo
+                    cd symfony-demo
+                    composer install 
+                    find . -type f -name "*.php" -exec sed -i.bak -E 's/error_reporting\(.*\);/error_reporting(0);/g' {} +
+
+            -   name: install Rector
+                if: matrix.command == 'rector'   
+                run: |
+                    composer require rector/rector:2.1.2 --dev
+                    cp .github/benchmark-files/rector.php .
+
+            -   name: Copy ini file
+                run: |
+                    sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+
+            -   name: Copy xdebug ini file
+                if: matrix.xdebug_mode != 'no'   
+                run: |
+                    sudo cp ./.github/benchmark-files/xdebug-benchmark.ini /etc/php/${{ matrix.php }}/cli/conf.d
+                    sudo cp ./.github/benchmark-files/xdebug-benchmark.ini /etc/php/${{ matrix.php }}/cgi/conf.d
+    
+            -   name: Set xdebug mode
+                run: echo "XDEBUG_MODE=${{ matrix.xdebug_mode }}" >> $GITHUB_ENV
+    
+            -   name: benchmark bench.php
+                if: matrix.command == 'bench'   
+                run: valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php ./.github/benchmark-files/bench.php
+
+            -   name: benchmark Symfony
+                if: matrix.command == 'symfony'   
+                run: |
+                    cd symfony-demo
+                    export SCRIPT_FILENAME="$(realpath public/index.php)"
+                    php-cgi public/index.php
+                    valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php-cgi public/index.php
+                    mv callgrind.out ..
+                    cd ..
+
+            -   name: benchmark rector.php
+                if: matrix.command == 'rector'   
+                run: valgrind --tool=callgrind --dump-instr=yes --callgrind-out-file=callgrind.out -- php vendor/bin/rector --dry-run --xdebug --debug || true
+
+            -   name: save matrix values
+                run: |
+                    awk '/^summary:/ { print $2 }' callgrind.out > results/php-${{ matrix.php }}_cmd-${{ matrix.command }}_xdebug-${{ matrix.xdebug_mode }}.txt
+                    echo "${{ matrix.php }},${{ matrix.command }},${{ matrix.xdebug_mode }}" > results/matrix-values-${{ matrix.php }}-${{ matrix.command }}-${{ matrix.xdebug_mode }}.txt
+
+            -   name: Upload result and matrix info
+                uses: actions/upload-artifact@v4
+                with:
+                    name: results-${{ matrix.command }}-${{ matrix.php }}-${{ matrix.xdebug_mode }}
+                    path: results/
+
+    performance:
+        needs: run-benchmark
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Download all artifacts
+                uses: actions/download-artifact@v4
+                with:
+                    path: results
+
+            -   name: Merge matrix values
+                run: |
+                    mkdir merged
+                    find results -name '*.txt' -exec cp {} merged/ \;
+                    cat merged/matrix-values-*.txt | sort | uniq > unique-matrix-values.txt
+                    cat unique-matrix-values.txt
+
+            -   name: Generate summary table
+                run: |
+                    export LC_NUMERIC=en_US.UTF-8
+                    echo "# 🕒 Performance Results" > summary.md 
+
+                    commands=$(cut -d',' -f2 unique-matrix-values.txt | sort | uniq)
+                    php_versions=$(cut -d',' -f1 unique-matrix-values.txt | sort | uniq)
+                    xdebug_modes=$(cut -d',' -f3 unique-matrix-values.txt | sort | uniq)
+
+                    for command in $commands; do
+                        echo "" >> summary.md
+                        echo "## **Command:** \`$command\`" >> summary.md
+                        for php in $php_versions; do
+                            echo "" >> summary.md
+                            echo "### **PHP Version:** \`$php\`" >> summary.md
+                            echo "" >> summary.md
+                            echo "| Xdebug | Instructions | Slowdown |" >> summary.md
+                            echo "|--------|-------------:|---------:|" >> summary.md
+
+                            base_file="merged/php-${php}_cmd-${command}_xdebug-no.txt"
+                            base_value=$(cat "$base_file")
+                            for xdebug in $xdebug_modes; do
+                                file="merged/php-${php}_cmd-${command}_xdebug-${xdebug}.txt"
+                                if [[ -f "$file" ]]; then
+                                    value=$(cat "$file")
+                                    if [[ "$xdebug" == "no" ]]; then
+                                        slowdown="0%"
+                                    else
+                                        slowdown=$(awk -v v=$value -v b=$base_value 'BEGIN { printf "%.1f%%", ((v - b) * 100) / b }')
+                                    fi
+                                    formatted_value=$(printf "%'d" "$value")
+                                    echo "| $xdebug | $formatted_value | $slowdown |" >> summary.md
+                                fi
+                            done
+                        done
+                    done
+
+            -   name: print summary
+                run: cat summary.md >> $GITHUB_STEP_SUMMARY
+
+            -   name: delete intermediary artifacts
+                uses: geekyeggo/delete-artifact@v5
+                with:
+                    name: results-*                
+                    

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ phpt.*
 !php_xdebug.stub.php
 !run-xdebug-tests.php
 !make-release.php
+!bench.php
+!rector.php


### PR DESCRIPTION
We want to be able to measure Xdebug's performance to see how different PRs affect it. To do this we will use Valgrind to count the number of instructions executed when running different php processes with Xdebug in any of its different modes. This is much more precise than measuring time as run time can be affected by a number of external elements. Measuring the number of executed instructions should give us a very good approximation to execution time. The usage of Valgrind to measure the number of instructions is inspired by the benchmarking that is done on the php-src using similar techniques and some of the code here has been directly derived from that implementation.

We run three different php processes which represent a number of different circumstances:
- The first one is an artificial benchmark which runs a number of algorithms. This process is the one that will be more affected by Xdebug as there is very little compilation (the process is just a single file) and lots of function calls. 
- The second one is running Rector with a small set of rules over a single file. This process represents a typical CLI tool run and is some middle ground in respect to Xdebug's influence. The number of compiled files is not too big and the number of function calls is not big either
- The third one involves doing a request on a Symfony endpoint. This process is the one less influenced by Xdebug because there is a huge number of files involved so that a lot of time is spent compiling/reading them.

We run these processes without Xdebug being loaded and then with it being loaded and with all its different modes activated. This allows us to understand the effect that Xdebug has on the execution time of these processes depending on these modes.

This benchmark is run in GitHub's CI infrastructure and it will be triggered in three different ways:
- It will run weekly on schedule
- It can be triggered manually
- It will run for any PR where the title of the PR starts with a specific prefix

The result of all these executions is summarised in a summary page which can be accessed through the Actions tab here in GitHub. You just need to open the corresponding workflow. Here is an example of this summary: